### PR TITLE
change breadcrumb prop to prop collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ Blackpink and working to fit into real world project.
 - [ ] Drawer
 - [ ] Dropdown
 - [ ] Flag / Notification / Toast
-- [x] Grid
+- [x] Flex
+- [ ] Grid
 - [ ] Heading
 - [ ] Input
+- [ ] Masonry
 - [ ] Modal
 - [ ] Pagination
 - [ ] Paragraph

--- a/src/Breadcrumb/Breadcrumb.tsx
+++ b/src/Breadcrumb/Breadcrumb.tsx
@@ -11,7 +11,7 @@ import { StyledBreadcrumbItem } from './StyledBreadcrumbItem';
 
 export const Breadcrumb: FunctionComponent<RefAttributes<any>> = forwardRef(
   (props, ref) => {
-    const { getContainerProps, getCurrentPageProps } = useBreadcrumb();
+    const { containerProps, currentPageProps } = useBreadcrumb();
 
     const childrenCount = Children.count(props.children);
 
@@ -21,7 +21,7 @@ export const Breadcrumb: FunctionComponent<RefAttributes<any>> = forwardRef(
       if (isLastItem) {
         return (
           <StyledBreadcrumbItem>
-            {cloneElement(child as any, getCurrentPageProps())}
+            {cloneElement(child as any, currentPageProps)}
           </StyledBreadcrumbItem>
         );
       }
@@ -30,7 +30,7 @@ export const Breadcrumb: FunctionComponent<RefAttributes<any>> = forwardRef(
     });
 
     return (
-      <nav ref={ref} {...getContainerProps({ role: null, ...props } as any)}>
+      <nav ref={ref} {...containerProps}>
         <StyledBreadcrumb>{childrenMapped}</StyledBreadcrumb>
       </nav>
     );

--- a/src/hooks/useBreadcrumb.ts
+++ b/src/hooks/useBreadcrumb.ts
@@ -1,28 +1,25 @@
-import { HTMLProps } from 'react';
-
 export interface IUseBreadCrumbReturnValue {
-  getContainerProps: <T>(options?: T & HTMLProps<any>) => T & HTMLProps<any>;
-  getCurrentPageProps: <T>(options?: T & HTMLProps<any>) => T & HTMLProps<any>;
+  containerProps: {
+    'aria-label': string;
+  };
+  currentPageProps: {
+    'aria-current': string;
+  };
 }
 
+// in this component, accessibility is the only "common ground" in most use cases
+// so a collection of prop is more than enough, rather than prop getters
 export function useBreadcrumb(): IUseBreadCrumbReturnValue {
-  const getContainerProps = ({ role, ...props }: HTMLProps<any> = {}): any => {
-    return {
-      'aria-label': 'Breadcrumb',
-      role,
-      ...props,
-    };
+  const containerProps = {
+    'aria-label': 'Breadcrumb',
   };
 
-  const getCurrentPageProps = (props: HTMLProps<any> = {}): any => {
-    return {
-      'aria-current': 'page',
-      ...props,
-    };
+  const currentPageProps = {
+    'aria-current': 'page',
   };
 
   return {
-    getContainerProps,
-    getCurrentPageProps,
+    containerProps,
+    currentPageProps,
   };
 }


### PR DESCRIPTION
For `<Breadcrumb />` component, accessibility is the only "common ground" in most use cases
So a collection of props is more than enough, rather than prop getters